### PR TITLE
DX-673: Prepend relative paths with the GitHub repo path in the helper lib READMEs

### DIFF
--- a/js/language.js
+++ b/js/language.js
@@ -1,13 +1,27 @@
 function loadReadme() {
     var language = $('.readme').data('language');
+    var branch = 'master';
+
+    var readmeUrl = 'https://raw.githubusercontent.com/twilio/twilio-' + language + '/' + branch + '/README.md';
+    var basePath = 'https://github.com/twilio/twilio-' + language + '/blob/' + branch + '/';
 
     $.ajax({
-        url: 'https://raw.githubusercontent.com/twilio/twilio-' + language + '/master/README.md'
+        url: readmeUrl
     }).done(function(data) {
         var converter = new showdown.Converter();
         converter.setFlavor('github');
         converter.setOption('simpleLineBreaks', false);
-        $('.readme')[0].innerHTML = converter.makeHtml(data);
+        converter.setOption('relativePathBaseUrl', basePath);
+
+        var html = converter.makeHtml(data);
+
+        // Prepend a base path to relative links or images.
+        // TODO: Remove this line once showdown adds support for base URLs:
+        // https://github.com/showdownjs/showdown/issues/536
+        html = html.replace(/(a href|img src)="(?!([a-z]+:)?\/\/|mailto|#)/gi, '$&' + basePath);
+
+        $('.readme')[0].innerHTML = html;
+
         $(document).ready(function() {
             $('.readme pre>code').each(function(i, block) {
                 hljs.highlightBlock(block);
@@ -16,4 +30,4 @@ function loadReadme() {
     })
 }
 
-window.onload = loadReadme(); 
+window.onload = loadReadme();


### PR DESCRIPTION
This change prepends the repo's GitHub location to relative links and images. READMEs sometimes have relative links which break when loading in a different location. For example, see the "contribute" links on this page: https://www.twilio.com/docs/libraries/reference/twilio-node/