### PR TITLE
chore: update GitHub branch references to use HEAD

### DIFF
--- a/js/language.js
+++ b/js/language.js
@@ -1,6 +1,6 @@
 function loadReadme() {
     var language = $('.readme').data('language');
-    var branch = 'master';
+    var branch = 'HEAD';
 
     var readmeUrl = 'https://raw.githubusercontent.com/twilio/twilio-' + language + '/' + branch + '/README.md';
     var basePath = 'https://github.com/twilio/twilio-' + language + '/blob/' + branch + '/';


### PR DESCRIPTION
The Twilio helpers have been migrated from 'master' to 'main' as the default branch. Using 'HEAD' will point to the latest version on the default branch.